### PR TITLE
Feature/swipe to play

### DIFF
--- a/components/CardDetailWindow.tsx
+++ b/components/CardDetailWindow.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  TouchableWithoutFeedback,
+  StyleSheet,
+  Dimensions,
+  Image,
+} from 'react-native';
+import { ChoiceType } from '@/app/types/models';
+
+interface CardDetailWindowProps {
+  choice: ChoiceType;
+  onClose: () => void;
+}
+
+const CardDetailWindow: React.FC<CardDetailWindowProps> = ({ choice, onClose }) => {
+  return (
+    <TouchableWithoutFeedback onPress={onClose}>
+      <View style={styles.overlay}>
+        <View style={styles.detailWindow}>
+          <Text style={styles.name}>{choice.name}</Text>
+          <Image
+            source={choice.img}
+            style={styles.image}
+          />
+          <Text style={styles.description}>{choice.description}</Text>
+        </View>
+      </View>
+    </TouchableWithoutFeedback>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  detailWindow: {
+    backgroundColor: '#fff',
+    padding: 20,
+    borderRadius: 10,
+    width: Dimensions.get('window').width * 0.8,
+    alignItems: 'center',
+  },
+  name: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 15,
+  },
+  image: {
+    width: 120,
+    height: 120,
+    resizeMode: 'contain',
+    marginBottom: 15,
+  },
+  description: {
+    fontSize: 16,
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+});
+
+export default CardDetailWindow;

--- a/components/JankenCard.tsx
+++ b/components/JankenCard.tsx
@@ -1,5 +1,6 @@
 // import "./JankenCard.css";
 import { Image, View, Text } from "react-native";
+import { GestureHandlerRootView, PanGestureHandler, PanGestureHandlerEventPayload } from 'react-native-gesture-handler';
 
 interface JankenCardProps {
   choice: {
@@ -10,7 +11,7 @@ interface JankenCardProps {
     level: number;
   };
   onClick: () => void;
-  onRightClick: (event: React.MouseEvent) => void;
+  onRightClick: () => void;
   isPlayerHand?: boolean;
   className?: string; // classNameを追加
 }
@@ -44,48 +45,69 @@ export default function JankenCard({
   const borderColor = adjustColorBrightness(baseColor);
   const imageSource = choice.img ? choice.img : require("@assets/zari.png");
 
-  return (
+  const onGestureEvent = ({ nativeEvent }: { nativeEvent: PanGestureHandlerEventPayload }) => {
+    if (nativeEvent.translationY < -50 && isPlayerHand) {
+      onClick(); // スワイプアップで選択
+    }
+  };
+
+  const handlePress = () => {
+    if (isPlayerHand) {
+      onRightClick();
+    }
+  };
+
+  const cardContent = (
     <View
       style={{
-      margin: 16,
-      padding: 16,
-      borderWidth: 2,
-      borderColor: borderColor,
-      borderRadius: 16,
-      backgroundColor: "#f9f9f9",
-      width: 80,
-      height: 128,
-      display: "flex",
-      flexDirection: "column",
-      alignItems: "center",
-      justifyContent: "space-around",
-      boxShadow: "0px 2px 5px rgba(0, 0, 0, 0.2)",
-      position: "relative",
-      overflow: "hidden",
+        margin: 16,
+        padding: 16,
+        borderWidth: 2,
+        borderColor: borderColor,
+        borderRadius: 16,
+        backgroundColor: "#f9f9f9",
+        width: 80,
+        height: 128,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "space-around",
+        position: "relative",
+        overflow: "hidden",
       }}
-      onTouchStart={onClick}
-      // onContextMenu={onRightClick}
+      onTouchStart={handlePress}
     >
       <View
-      style={{
-        position: "relative",
-        width: 80,
-        height: 80,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-      >
-      <Image
-        source={imageSource}
         style={{
-        width: 80,
-        height: 80,
-        resizeMode: "contain",
+          position: "relative",
+          width: 80,
+          height: 80,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
         }}
-      />
+      >
+        <Image
+          source={imageSource}
+          style={{
+            width: 80,
+            height: 80,
+            resizeMode: "contain",
+          }}
+        />
       </View>
       <Text style={{ marginTop: 8, fontWeight: "bold" }}>{choice.name}</Text>
     </View>
+  );
+
+  // プレイヤーの手札の場合のみスワイプ機能を追加
+  return isPlayerHand ? (
+    <GestureHandlerRootView>
+      <PanGestureHandler onGestureEvent={onGestureEvent}>
+        {cardContent}
+      </PanGestureHandler>
+    </GestureHandlerRootView>
+  ) : (
+    cardContent
   );
 }

--- a/components/JankenCard.tsx
+++ b/components/JankenCard.tsx
@@ -17,7 +17,12 @@ interface JankenCardProps {
 
 const adjustColorBrightness = (color: string): string => {
   const brightnessAdjustment = 1;
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
+  const match = color.match(/\d+/g);
+  if (!match || match.length < 3) {
+    console.error('Invalid color format:', color);
+    return color;
+  }
+  const [r, g, b] = match.map(Number);
   return `rgb(${Math.floor(r * brightnessAdjustment)}, ${Math.floor(
     g * brightnessAdjustment
   )}, ${Math.floor(b * brightnessAdjustment)})`;

--- a/components/JankenCard.tsx
+++ b/components/JankenCard.tsx
@@ -35,8 +35,12 @@ export default function JankenCard({
 
   const panResponder = useRef(
     PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponder: () => true,
+      onStartShouldSetPanResponder: (evt, gestureState) => {
+        return Math.abs(gestureState.dx) > 2 || Math.abs(gestureState.dy) > 2;
+      },
+      onMoveShouldSetPanResponder: (evt, gestureState) => {
+        return Math.abs(gestureState.dx) > 2 || Math.abs(gestureState.dy) > 2;
+      },
 
       onPanResponderGrant: () => {
         setHasTriggeredSwipe(false);
@@ -86,6 +90,7 @@ export default function JankenCard({
   return (
     <View {...panResponder.panHandlers}>
       <Pressable
+        hitSlop={5}
         onPress={handlePress}
         style={{
           margin: 16,

--- a/components/ResultWindow.tsx
+++ b/components/ResultWindow.tsx
@@ -35,8 +35,8 @@ const ResultWindow: React.FC<ResultWindowProps> = ({
             <View style={styles.choice}>
               <JankenCard
                 choice={showResult.computerChoice}
-                onClick={() => {}}
-                onRightClick={() => {}}
+                onSwipeUp={() => {}}
+                onCardPress={() => {}}
               />
             </View>
           </View>
@@ -68,8 +68,8 @@ const ResultWindow: React.FC<ResultWindowProps> = ({
           <View style={styles.choice}>
             <JankenCard
               choice={showResult.playerChoice}
-              onClick={() => {}}
-              onRightClick={() => {}}
+              onSwipeUp={() => {}}
+              onCardPress={() => {}}
             />
           </View>
         </View>

--- a/components/ResultWindow.tsx
+++ b/components/ResultWindow.tsx
@@ -7,7 +7,7 @@ import {
   Dimensions,
 } from 'react-native';
 import JankenCard from './JankenCard';
-import { ChoiceType } from './choices';
+import { ChoiceType } from '@/app/types/models';
 
 interface ResultWindowProps {
   showResult: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@react-navigation/bottom-tabs": "^7.0.0",
         "@react-navigation/native": "^7.0.13",
         "@react-navigation/native-stack": "^7.1.14",
+        "@reduxjs/toolkit": "^2.5.0",
         "expo": "~52.0.17",
         "expo-blur": "~14.0.1",
         "expo-constants": "~17.0.3",
@@ -32,7 +33,8 @@
         "react-native-safe-area-context": "4.12.0",
         "react-native-screens": "~4.1.0",
         "react-native-web": "~0.19.13",
-        "react-native-webview": "13.12.5"
+        "react-native-webview": "13.12.5",
+        "react-redux": "^9.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -4010,6 +4012,36 @@
         "nanoid": "3.3.7"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.5.0.tgz",
+      "integrity": "sha512-awNe2oTodsZ6LmRqmkFhtb/KH03hUhxOamEQy411m3Njj3BbFvoBovxo4Q1cBWnV1ErprVj9MlF0UPXkng0eyg==",
+      "license": "MIT",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/@remix-run/node": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.15.0.tgz",
@@ -4374,6 +4406,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -8090,6 +8128,16 @@
       },
       "engines": {
         "node": ">=16.x"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -12401,6 +12449,29 @@
         "async-limiter": "~1.0.0"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -12488,6 +12559,21 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/regenerate": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@react-navigation/bottom-tabs": "^7.0.0",
     "@react-navigation/native": "^7.0.13",
     "@react-navigation/native-stack": "^7.1.14",
+    "@reduxjs/toolkit": "^2.5.0",
     "expo": "~52.0.17",
     "expo-blur": "~14.0.1",
     "expo-constants": "~17.0.3",
@@ -39,7 +40,8 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.1.0",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.5"
+    "react-native-webview": "13.12.5",
+    "react-redux": "^9.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/screens/JankenGame.tsx
+++ b/screens/JankenGame.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   View,
   Text,
@@ -13,6 +13,7 @@ import ResultWindow from "../components/ResultWindow";
 import ScoreWindow from "../components/ScoreWindow";
 import { useJankenGame } from "../app/hooks/useJankenGame";
 import { ChoiceType } from "../app/types/models";
+import CardDetailWindow from "../components/CardDetailWindow";
 
 
 export default function JankenGame({
@@ -35,6 +36,20 @@ export default function JankenGame({
     closeResult,
   } = useJankenGame(onBackClick);
 
+  const [selectedCard, setSelectedCard] = useState<ChoiceType | null>(null);
+  const [showCardDetail, setShowCardDetail] = useState(false);
+
+  const handleCardPress = (choice: ChoiceType) => {
+    console.log("handleCardPress", choice);
+    setSelectedCard(choice);
+    setShowCardDetail(true);
+  };
+
+  const closeCardDetail = () => {
+    setShowCardDetail(false);
+    setSelectedCard(null);
+  };
+
   return (
     <ScrollView style={styles.container}>
       {/* Header */}
@@ -46,7 +61,12 @@ export default function JankenGame({
       {/* Enemy Section */}
       <View style={styles.enemyContainer}>
         <Text style={styles.enemyText}>ランダムロボ</Text>
-        <Image source={enemyImage} style={styles.enemyImage} />
+        <Image 
+          source={typeof enemyImage === 'string' 
+            ? { uri: enemyImage } 
+            : enemyImage} 
+          style={styles.enemyImage} 
+        />
       </View>
 
       {/* Computer Cards */}
@@ -70,7 +90,7 @@ export default function JankenGame({
             key={index}
             choice={choice}
             onClick={() => handlePlayerChoice(index)}
-            onRightClick={() => {}}
+            onRightClick={() => handleCardPress(choice)}
             isPlayerHand
           />
         ))}
@@ -95,6 +115,14 @@ export default function JankenGame({
 
       {showScoreWindow && (
         <ScoreWindow winCount={winCount} closeScoreWindow={closeScoreWindow} />
+      )}
+
+      {/* Card Detail Modal */}
+      {showCardDetail && selectedCard && (
+        <CardDetailWindow
+          choice={selectedCard}
+          onClose={closeCardDetail}
+        />
       )}
     </ScrollView>
   );

--- a/screens/JankenGame.tsx
+++ b/screens/JankenGame.tsx
@@ -76,8 +76,8 @@ export default function JankenGame({
           <JankenCard
             key={index}
             choice={choice}
-            onClick={() => {}}
-            onRightClick={() => {}}
+            onSwipeUp={() => {}}
+            onCardPress={() => handleCardPress(choice)}
           />
         ))}
       </View>
@@ -89,8 +89,8 @@ export default function JankenGame({
           <JankenCard
             key={index}
             choice={choice}
-            onClick={() => handlePlayerChoice(index)}
-            onRightClick={() => handleCardPress(choice)}
+            onSwipeUp={() => handlePlayerChoice(index)}
+            onCardPress={() => handleCardPress(choice)}
             isPlayerHand
           />
         ))}


### PR DESCRIPTION
ハードウェアの環境依存なくすため、右クリックを操作から排除
上にカードをスワイプ→プレイ
カードをタップ→詳細表示
に変更！
![image](https://github.com/user-attachments/assets/b9405c91-9703-49f1-b519-cb526261aae4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `CardDetailWindow` component for displaying card details in a modal.
	- Enhanced `JankenCard` interactions with swipe and press gestures.
	- Updated `JankenGame` to manage card selection and display details in the new modal.

- **Bug Fixes**
	- Improved handling of card interactions and visibility of the detail modal.

- **Chores**
	- Updated dependencies in `package.json` to include `@reduxjs/toolkit` and `react-redux`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->