### PR TITLE
カード詳細表示の際、相手カード枠の色で勝敗を

### DIFF
--- a/app/types/models.ts
+++ b/app/types/models.ts
@@ -4,6 +4,7 @@ export interface ChoiceType {
   description: string;
   type: ChoiceTypeEnum;
   level: number;
+  id: number;
 }
 
 export type ChoiceTypeEnum = "rock" | "scissors" | "paper" | "other";
@@ -15,6 +16,7 @@ export const choices: ChoiceType[] = [
     description: "ふつうのグー",
     type: "rock",
     level: 0,
+    id: 0,
   },
   {
     name: "チョキ",
@@ -22,6 +24,7 @@ export const choices: ChoiceType[] = [
     description: "ふつうのチョキ",
     type: "scissors",
     level: 0,
+    id: 1,
   },
   {
     name: "パー",
@@ -29,6 +32,7 @@ export const choices: ChoiceType[] = [
     description: "ふつうのパー",
     type: "paper",
     level: 0,
+    id: 2,
   },
   {
     name: "金の玉",
@@ -36,6 +40,7 @@ export const choices: ChoiceType[] = [
     description: "高位のグー。グーに勝つ",
     type: "rock",
     level: 1,
+    id: 3,
   },
   {
     name: "ザリガニ",
@@ -43,6 +48,7 @@ export const choices: ChoiceType[] = [
     description: "高位のチョキ。チョキに勝つ",
     type: "scissors",
     level: 1,
+    id: 4,
   },
   {
     name: "札",
@@ -50,6 +56,7 @@ export const choices: ChoiceType[] = [
     description: "高位のパー。パーに勝つ",
     type: "paper",
     level: 1,
+    id: 5,
   },
   {
     name: "隕石",
@@ -57,6 +64,7 @@ export const choices: ChoiceType[] = [
     description: "最高位のグー。他のグー系に勝つ",
     type: "rock",
     level: 2,
+    id: 6,
   },
   {
     name: "村正",
@@ -64,6 +72,7 @@ export const choices: ChoiceType[] = [
     description: "最高位のチョキ。他のチョキ系に勝つ",
     type: "scissors",
     level: 2,
+    id: 7,
   },
   {
     name: "愛",
@@ -71,6 +80,7 @@ export const choices: ChoiceType[] = [
     description: "最高位のパー。他のパー系に勝つ",
     type: "paper",
     level: 2,
+    id: 8,
   },
   {
     name: "バリアー",
@@ -78,6 +88,7 @@ export const choices: ChoiceType[] = [
     description: "どの手ともあいこになる",
     type: "other",
     level: 0,
+    id: 9,
   },
 ];
 

--- a/components/JankenCard.tsx
+++ b/components/JankenCard.tsx
@@ -1,20 +1,16 @@
 import { Image, View, Text, Pressable, PanResponder, Animated } from "react-native";
 import { useRef } from 'react';
 import { ChoiceType } from "../app/types/models";
+import getResult from "../app/lib/get_result";
 
 interface JankenCardProps {
-  choice: {
-    name: string;
-    img: string;
-    description: string;
-    type: string;
-    level: number;
-  };
+  choice: ChoiceType;
   onSwipeUp: () => void;
   onCardPress: () => void;
   isPlayerHand?: boolean;
   className?: string;
   showResult: { playerChoice: ChoiceType; computerChoice: ChoiceType; result: string; } | null;
+  selectedCard?: ChoiceType | null;
 }
 
 const adjustColorBrightness = (color: string): string => {
@@ -37,6 +33,7 @@ export default function JankenCard({
   isPlayerHand = false,
   className = "",
   showResult,
+  selectedCard,
 }: JankenCardProps) {
   const isSwipingRef = useRef(false);
   const pan = useRef(new Animated.ValueXY()).current;
@@ -88,6 +85,26 @@ export default function JankenCard({
   const borderColor = adjustColorBrightness(baseColor);
   const imageSource = choice.img || require("@assets/zari.png");
 
+  const getBorderColor = () => {
+    if (!selectedCard || isPlayerHand) return borderColor;
+    
+    if (getResult(selectedCard, choice) === "win") {
+      return "rgb(0, 255, 0)";
+    } else if (getResult(selectedCard, choice) === "lose") {
+      return "rgb(255, 0, 0)";
+    }
+    return borderColor;
+  };
+
+  const getBorderWidth = () => {
+    if (!selectedCard || isPlayerHand) return 2;
+    
+    if (getResult(selectedCard, choice) === "win" || getResult(choice, selectedCard) === "win") {
+      return 4;
+    }
+    return 2;
+  };
+
   return (
     <Animated.View
       {...(showResult === null ? panResponder.panHandlers : {})}
@@ -101,8 +118,8 @@ export default function JankenCard({
         style={{
           margin: 16,
           padding: 16,
-          borderWidth: 2,
-          borderColor: borderColor,
+          borderWidth: getBorderWidth(),
+          borderColor: getBorderColor(),
           borderRadius: 16,
           backgroundColor: "#f9f9f9",
           width: 80,

--- a/screens/JankenGame.tsx
+++ b/screens/JankenGame.tsx
@@ -47,6 +47,8 @@ export default function JankenGame({
 
   const cardRefs = useRef<(View | HTMLDivElement | null)[]>([]);
 
+  const isWeb = Platform.OS === "web";
+
   const updateCardPosition = (index: number) => {
     if (cardRefs.current[index]) {
       if (isWeb) {
@@ -63,13 +65,13 @@ export default function JankenGame({
           }));
         }
       } else {
-        (cardRefs.current[index] as View)?.measure(
-          (x, y, width, height, pageX, pageY) => {
+        (cardRefs.current[index] as View)?.measureInWindow(
+          (x, y, width, height) => {
             setCardPositions((prev) => ({
               ...prev,
               [index]: {
-                x: pageX - width / 2,
-                y: pageY - height / 2,
+                x: x - width / 2,
+                y: y - height / 2,
               },
             }));
           }
@@ -78,8 +80,7 @@ export default function JankenGame({
     }
   };
 
-  // プラットフォーム判定
-  const isWeb = Platform.OS === "web";
+
 
   useEffect(() => {
     const updateAllCardPositions = () => {
@@ -98,8 +99,7 @@ export default function JankenGame({
   }, [playerChoices]);
 
   const handleCardPress = (choice: ChoiceType) => {
-    if (!showResult) {
-      // リザルト表示中は詳細を表示しない
+    if (!showResult && playerState !== 'shuffling') {
       setSelectedCard(choice);
       setShowDetail(true);
     }
@@ -159,8 +159,9 @@ export default function JankenGame({
                 <JankenCard
                   choice={choice}
                   onSwipeUp={() => {}}
-                  onCardPress={() => !showResult && handleCardPress(choice)}
+                  onCardPress={() => handleCardPress(choice)}
                   showResult={showResult}
+                  selectedCard={showDetail ? selectedCard : null}
                 />
               </View>
             ))
@@ -191,7 +192,7 @@ export default function JankenGame({
         <View style={styles.cardContainer}>
           {(playerChoices || []).map((choice, index) => (
             <View
-              key={index}
+              key={`player-card-${index}-${choice.id}`}
               ref={(el) => {
                 cardRefs.current[index] = el;
               }}
@@ -202,7 +203,7 @@ export default function JankenGame({
               <JankenCard
                 choice={choice}
                 onSwipeUp={() => handleSwipeUp(index)}
-                onCardPress={() => handleCardPress(choice)}
+                onCardPress={() => !showResult && handleCardPress(choice)}
                 isPlayerHand
                 showResult={showResult}
               />
@@ -213,9 +214,10 @@ export default function JankenGame({
 
       {/* Player Info */}
       <View style={styles.playerContainer}>
-        <Text style={styles.playerText}>ライフ: {life}</Text>
-        <Text style={styles.playerText}>勝利数: {winCount}</Text>
-        <Text style={styles.playerText}>引き分け: {drawCount}</Text>
+        <Text style={styles.playerText}>
+          {Array(life).fill('❤️').join('')}
+        </Text>
+        <Text style={styles.playerText}>⭐️ {winCount}</Text>
       </View>
 
       {showScoreWindow && (
@@ -266,19 +268,16 @@ const styles = StyleSheet.create({
     marginVertical: 10,
   },
   playerContainer: {
-    marginTop: 20,
-    alignItems: "center",
-    transform: [{ translateX: -50 }],
-  },
-  playerImage: {
-    width: "20%",
-    height: "15%",
-    resizeMode: "contain",
+    marginTop: 40,
+    marginBottom: 10,
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 20,
   },
   playerInfo: {
     borderLeftWidth: 0,
     paddingLeft: 30,
-    marginLeft: -20,
     color: "black",
     width: 100,
     textAlign: "left",
@@ -287,25 +286,6 @@ const styles = StyleSheet.create({
   playerText: {
     fontSize: 16,
     fontWeight: "bold",
-  },
-  lifeContainer: {
-    margin: -5,
-  },
-  winContainer: {
-    margin: -5,
-  },
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: "rgba(0, 0, 0, 0.5)",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  modalContent: {
-    backgroundColor: "#fff",
-    padding: 20,
-    borderRadius: 10,
-    maxWidth: "80%",
-    textAlign: "center",
   },
   gameArea: {
     flex: 1,

--- a/screens/JankenGame.tsx
+++ b/screens/JankenGame.tsx
@@ -215,7 +215,7 @@ export default function JankenGame({
       {/* Player Info */}
       <View style={styles.playerContainer}>
         <Text style={styles.playerText}>
-          {Array(life).fill('❤️').join('')}
+          {life > 0 ?? Array(life).fill('❤️').join('')}
         </Text>
         <Text style={styles.playerText}>⭐️ {winCount}</Text>
       </View>


### PR DESCRIPTION
<img width="401" alt="スクリーンショット 2024-12-30 15 44 08" src="https://github.com/user-attachments/assets/0a19f314-58a7-4c59-8ae7-be37558dfd38" />
詳細表示の際、勝てる相手のカードを緑、負ける相手のカードを赤で示すように
ついでに使ってないスタイル定義いろいろ消した